### PR TITLE
Chartboost 8.2.0 support

### DIFF
--- a/Chartboost/CHANGELOG.md
+++ b/Chartboost/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-  * 8.0.4.0
+  * 8.2.0.0
       * This version of the adapters has been certified with Chartboost 8.2.0.
       * Add support for Chartboost CHBDataUseConsent API. 
 

--- a/Chartboost/CHANGELOG.md
+++ b/Chartboost/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## Changelog
+
+  * 8.0.4.0
+      * This version of the adapters has been certified with Chartboost 8.2.0.
+      * Add support for Chartboost CHBDataUseConsent API. 
+
   * 8.1.0.2
       * Refactor non-native adapter classes to use the new consolidated API from MoPub.
       * To use this and newer adapter versions, you must use MoPub 5.13.0 or newer.

--- a/Chartboost/ChartboostAdapterConfiguration.m
+++ b/Chartboost/ChartboostAdapterConfiguration.m
@@ -1,7 +1,7 @@
 #import "ChartboostAdapterConfiguration.h"
 #import "ChartboostRouter.h"
 
-#define CHARTBOOST_ADAPTER_VERSION  @"8.1.0.2"
+#define CHARTBOOST_ADAPTER_VERSION  @"8.2.0.0"
 #define MOPUB_NETWORK_NAME          @"chartboost"
 
 // Constants

--- a/Chartboost/ChartboostBannerCustomEvent.m
+++ b/Chartboost/ChartboostBannerCustomEvent.m
@@ -50,26 +50,14 @@
     // The banner view bounds will have by default the same size as the requested ad size.
     // If the requested width or height is 0, as it happens for the first ad loaded using MoPub's max ad size presets,
     // we change the banner bounds to a standard size, so it is visible.
-    CGSize standardSize = [self standardSizeFromSize:size];
     CGSize bannerSize = banner.bounds.size;
     if (size.width <= 0) {
-        bannerSize.width = standardSize.width;
+        bannerSize.width = CHBBannerSizeStandard.width;
     }
     if (size.height <= 0) {
-        bannerSize.height = standardSize.height;
+        bannerSize.height = CHBBannerSizeStandard.height;
     }
     banner.bounds = CGRectMake(0, 0, bannerSize.width, bannerSize.height);
-}
-
-- (CHBBannerSize)standardSizeFromSize:(CGSize)size
-{
-    if (size.height >= CHBBannerSizeLeaderboard.height && size.width >= CHBBannerSizeLeaderboard.width) {
-        return CHBBannerSizeLeaderboard;
-    } else if (size.height >= CHBBannerSizeMedium.height && size.width >= CHBBannerSizeMedium.width) {
-        return CHBBannerSizeMedium;
-    } else {
-        return CHBBannerSizeStandard;
-    }
 }
 
 - (BOOL)enableAutomaticImpressionAndClickTracking

--- a/Chartboost/ChartboostBannerCustomEvent.m
+++ b/Chartboost/ChartboostBannerCustomEvent.m
@@ -38,10 +38,38 @@
             weakSelf.banner.delegate = nil;
             weakSelf.banner = [[CHBBanner alloc] initWithSize:integerSize location:location mediation:[ChartboostRouter mediation] delegate:weakSelf];
             weakSelf.banner.automaticallyRefreshesContent = NO;
+            [weakSelf setInitialBoundsForBanner:weakSelf.banner size:integerSize];
             
             [weakSelf.banner showFromViewController:[weakSelf.delegate inlineAdAdapterViewControllerForPresentingModalView:weakSelf]];
         });
     }];
+}
+
+- (void)setInitialBoundsForBanner:(CHBBanner *)banner size:(CGSize)size
+{
+    // The banner view bounds will have by default the same size as the requested ad size.
+    // If the requested width or height is 0, as it happens for the first ad loaded using MoPub's max ad size presets,
+    // we change the banner bounds to a standard size, so it is visible.
+    CGSize standardSize = [self standardSizeFromSize:size];
+    CGSize bannerSize = banner.bounds.size;
+    if (size.width <= 0) {
+        bannerSize.width = standardSize.width;
+    }
+    if (size.height <= 0) {
+        bannerSize.height = standardSize.height;
+    }
+    banner.bounds = CGRectMake(0, 0, bannerSize.width, bannerSize.height);
+}
+
+- (CHBBannerSize)standardSizeFromSize:(CGSize)size
+{
+    if (size.height >= CHBBannerSizeLeaderboard.height && size.width >= CHBBannerSizeLeaderboard.width) {
+        return CHBBannerSizeLeaderboard;
+    } else if (size.height >= CHBBannerSizeMedium.height && size.width >= CHBBannerSizeMedium.width) {
+        return CHBBannerSizeMedium;
+    } else {
+        return CHBBannerSizeStandard;
+    }
 }
 
 - (BOOL)enableAutomaticImpressionAndClickTracking

--- a/Chartboost/ChartboostRouter.m
+++ b/Chartboost/ChartboostRouter.m
@@ -45,15 +45,15 @@ static NSString * const kChartboostAppSignatureKey = @"appSignature";
     if ([mopub isGDPRApplicable] == MPBoolYes) {
         if ([mopub allowLegitimateInterest]) {
             if ([mopub currentConsentStatus] == MPConsentStatusDenied || [mopub currentConsentStatus] == MPConsentStatusDoNotTrack) {
-                [Chartboost setPIDataUseConsent:NoBehavioral];
+                [Chartboost addDataUseConsent:[CHBGDPRDataUseConsent gdprConsent:CHBGDPRConsentNonBehavioral]];
             } else {
-                [Chartboost setPIDataUseConsent:YesBehavioral];
+                [Chartboost addDataUseConsent:[CHBGDPRDataUseConsent gdprConsent:CHBGDPRConsentBehavioral]];
             }
         } else {
             if ([mopub canCollectPersonalInfo]) {
-                [Chartboost setPIDataUseConsent:YesBehavioral];
+                [Chartboost addDataUseConsent:[CHBGDPRDataUseConsent gdprConsent:CHBGDPRConsentBehavioral]];
             } else {
-                [Chartboost setPIDataUseConsent:NoBehavioral];
+                [Chartboost addDataUseConsent:[CHBGDPRDataUseConsent gdprConsent:CHBGDPRConsentNonBehavioral]];
             }
         }
     }


### PR DESCRIPTION
Updated to use new consent methods.

**Update: Banner size fix**
After some tests, I found that banner that use MoPub's "max ad size" presets (e.g.: kMPPresetMaxAdSize90Height, kMPPresetMaxAdSize250Height), when loaded for the first time, are requested with a width of value 0. Next loads, manual or due to auto-refresh, are requested with the maximum available width.
This causes the Chartboost banner to be of width 0 the first time the ad is loaded. MoPub does not do any custom layout of the mediated banner inside their banner container, so the original banner bounds are used to define the visible banner size, and these bounds (for Chartboost banners) correspond to the requested banner size.
The result is a non-visible first banner.

How banner looks now (second time):
![fix2 - first ad](https://user-images.githubusercontent.com/9442254/86941345-202d5480-c144-11ea-8fe5-9121899de655.png)

**First fix: forcing standardized Chartboost sizes**
Basically, transform the requested size into one of the Chartboost predefined sizes before creating the banner. This is at first look the safest option. I've seen some other networks do this (others directly fail the request when a size 0 comes their way).
The only issue is that publishers are required to properly resize the banner view according to the new banner size (requested size and final size don't match anymore). To do this they need to use a parameter passed by MoPub in one of its delegates. In the comments of this method, MoPub recommends that the user resizes the banner using that parameter:

```
/**
 * Sent when an ad view successfully loads an ad.
 *
 * Your implementation of this method should insert the ad view into the view hierarchy, if you
 * have not already done so.
 *
 * @param view The ad view sending the message.
 * @param adSize The size of the ad that was successfully loaded. It is recommended to resize
 * the @c MPAdView frame to match the height of the loaded ad.
 */
- (void)adViewDidLoadAd:(MPAdView *)view adSize:(CGSize)adSize;
```

Can we trust that publishers are doing this?

What happens if publisher does it right:
![fix1 - resize by pub](https://user-images.githubusercontent.com/9442254/86941831-b19cc680-c144-11ea-9f11-d6fd3d3739a2.png)

What happens if they don't:
![fix1 - no resize by pub](https://user-images.githubusercontent.com/9442254/86941843-b9f50180-c144-11ea-9acc-35ff78176656.png)

**Second fix: layout banner using a standardized size if needed**
Here we don't change the size we pass to Chartboost banner (the size we request to DA is the same too). We only change the banner view bounds, when 0 (first time it is loaded), setting them to a standard banner size.

First ad loaded looks like:
![fix2 - first ad](https://user-images.githubusercontent.com/9442254/86942142-19531180-c145-11ea-874d-500a21d31e48.png)
(here we used a standard width, while keeping the requested height)

Second ad loaded looks like:
![fix2 - second ad](https://user-images.githubusercontent.com/9442254/86942159-1f48f280-c145-11ea-834c-101d5e079e81.png)
(here we used the original requested size, which is a "Max width X 250 height"


