### PR TITLE
8.3.2.0

### DIFF
--- a/Chartboost/ChartboostAdapterConfiguration.m
+++ b/Chartboost/ChartboostAdapterConfiguration.m
@@ -1,7 +1,7 @@
 #import "ChartboostAdapterConfiguration.h"
 #import "ChartboostRouter.h"
 
-#define CHARTBOOST_ADAPTER_VERSION  @"8.2.1.0"
+#define CHARTBOOST_ADAPTER_VERSION  @"8.3.2.0"
 #define MOPUB_NETWORK_NAME          @"chartboost"
 
 // Constants

--- a/Chartboost/ChartboostRouter.h
+++ b/Chartboost/ChartboostRouter.h
@@ -21,6 +21,8 @@
     #import "Chartboost+Mediation.h"
 #endif
 
+#define SYSTEM_VERSION_LESS_THAN(v)                 ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface ChartboostRouter : NSObject

--- a/Chartboost/ChartboostRouter.h
+++ b/Chartboost/ChartboostRouter.h
@@ -30,4 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)startWithParameters:(NSDictionary *)parameters completion:(void(^)(BOOL))completion;
 @end
 
+/// Minimum OS version.
+static NSString *const kGADMAdapterMinimumOSVersion = @"10.0";
+
 NS_ASSUME_NONNULL_END

--- a/Chartboost/ChartboostRouter.h
+++ b/Chartboost/ChartboostRouter.h
@@ -30,7 +30,4 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)startWithParameters:(NSDictionary *)parameters completion:(void(^)(BOOL))completion;
 @end
 
-/// Minimum OS version.
-static NSString *const kGADMAdapterMinimumOSVersion = @"10.0";
-
 NS_ASSUME_NONNULL_END

--- a/Chartboost/ChartboostRouter.m
+++ b/Chartboost/ChartboostRouter.m
@@ -46,12 +46,7 @@ static NSString * const kGADMAdapterMinimumOSVersion = @"10.0";
 }
 
 + (void)setDataUseConsentWithMopubConfiguration
-{
-    if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
-        NSLog(@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion);
-        return;
-    }
-    
+{    
     MoPub *mopub = [MoPub sharedInstance];
     if ([mopub isGDPRApplicable] == MPBoolYes) {
         if ([mopub allowLegitimateInterest]) {
@@ -74,6 +69,7 @@ static NSString * const kGADMAdapterMinimumOSVersion = @"10.0";
 {
     if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
         NSLog(@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion);
+        completion(NO);
         return;
     }
     

--- a/Chartboost/ChartboostRouter.m
+++ b/Chartboost/ChartboostRouter.m
@@ -10,6 +10,7 @@
 
 static NSString * const kChartboostAppIdKey        = @"appId";
 static NSString * const kChartboostAppSignatureKey = @"appSignature";
+static NSString * const kGADMAdapterMinimumOSVersion = @"10.0";
 
 @implementation ChartboostRouter
 

--- a/Chartboost/ChartboostRouter.m
+++ b/Chartboost/ChartboostRouter.m
@@ -63,7 +63,9 @@ static NSString * const kChartboostMinimumOSVersion = @"10.0";
 + (void)startWithParameters:(NSDictionary *)parameters completion:(void (^)(BOOL))completion
 {
     if (SYSTEM_VERSION_LESS_THAN(kChartboostMinimumOSVersion)) {
-        NSLog(@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kChartboostMinimumOSVersion);
+        NSString* logError = [NSString stringWithFormat:@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kChartboostMinimumOSVersion];
+        NSError *error = [NSError errorWithCode:MOPUBErrorUnknown localizedDescription:logError];
+        MPLogEvent([MPLogEvent error:error message:nil]);
         completion(NO);
         return;
     }

--- a/Chartboost/ChartboostRouter.m
+++ b/Chartboost/ChartboostRouter.m
@@ -23,11 +23,6 @@ static NSString * const kGADMAdapterMinimumOSVersion = @"10.0";
 
 + (void)setLoggingLevel:(MPBLogLevel)loggingLevel
 {
-    if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
-        NSLog(@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion);
-        return;
-    }
-    
     CBLoggingLevel chbLoggingLevel = [self chartboostLoggingLevelFromMopubLevel:loggingLevel];
     [Chartboost setLoggingLevel:chbLoggingLevel];
 }

--- a/Chartboost/ChartboostRouter.m
+++ b/Chartboost/ChartboostRouter.m
@@ -64,7 +64,8 @@ static NSString * const kChartboostMinimumOSVersion = @"10.0";
 {
     if (SYSTEM_VERSION_LESS_THAN(kChartboostMinimumOSVersion)) {
         NSString* logError = [NSString stringWithFormat:@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kChartboostMinimumOSVersion];
-        NSError *error = [NSError errorWithCode:MOPUBErrorUnknown localizedDescription:logError];
+        NSError *error = [NSError errorWithCode:MOPUBErrorUnknown
+                           localizedDescription:logError];
         MPLogEvent([MPLogEvent error:error message:nil]);
         completion(NO);
         return;

--- a/Chartboost/ChartboostRouter.m
+++ b/Chartboost/ChartboostRouter.m
@@ -10,7 +10,7 @@
 
 static NSString * const kChartboostAppIdKey        = @"appId";
 static NSString * const kChartboostAppSignatureKey = @"appSignature";
-static NSString * const kGADMAdapterMinimumOSVersion = @"10.0";
+static NSString * const kChartboostMinimumOSVersion = @"10.0";
 
 @implementation ChartboostRouter
 
@@ -62,8 +62,8 @@ static NSString * const kGADMAdapterMinimumOSVersion = @"10.0";
 
 + (void)startWithParameters:(NSDictionary *)parameters completion:(void (^)(BOOL))completion
 {
-    if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
-        NSLog(@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion);
+    if (SYSTEM_VERSION_LESS_THAN(kChartboostMinimumOSVersion)) {
+        NSLog(@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kChartboostMinimumOSVersion);
         completion(NO);
         return;
     }

--- a/Chartboost/ChartboostRouter.m
+++ b/Chartboost/ChartboostRouter.m
@@ -22,6 +22,11 @@ static NSString * const kChartboostAppSignatureKey = @"appSignature";
 
 + (void)setLoggingLevel:(MPBLogLevel)loggingLevel
 {
+    if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
+        NSLog(@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion);
+        return;
+    }
+    
     CBLoggingLevel chbLoggingLevel = [self chartboostLoggingLevelFromMopubLevel:loggingLevel];
     [Chartboost setLoggingLevel:chbLoggingLevel];
 }
@@ -41,6 +46,11 @@ static NSString * const kChartboostAppSignatureKey = @"appSignature";
 
 + (void)setDataUseConsentWithMopubConfiguration
 {
+    if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
+        NSLog(@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion);
+        return;
+    }
+    
     MoPub *mopub = [MoPub sharedInstance];
     if ([mopub isGDPRApplicable] == MPBoolYes) {
         if ([mopub allowLegitimateInterest]) {
@@ -61,6 +71,11 @@ static NSString * const kChartboostAppSignatureKey = @"appSignature";
 
 + (void)startWithParameters:(NSDictionary *)parameters completion:(void (^)(BOOL))completion
 {
+    if (SYSTEM_VERSION_LESS_THAN(kGADMAdapterMinimumOSVersion)) {
+        NSLog(@"Chartboost minimum supported OS version is iOS %@. Requested action is a no-op.", kGADMAdapterMinimumOSVersion);
+        return;
+    }
+    
     NSString *appId = parameters[kChartboostAppIdKey];
     NSString *appSignature = parameters[kChartboostAppSignatureKey];
     


### PR DESCRIPTION
Checking Chartboost minimum iOS version available to prevent making calls that would expect a callback.